### PR TITLE
make Redactor options customizable via JS

### DIFF
--- a/redactor/widgets.py
+++ b/redactor/widgets.py
@@ -14,7 +14,7 @@ class RedactorEditor(widgets.Textarea):
     init_js = '''<script type="text/javascript">
                     jQuery(document).ready(function(jQuery){
                         var $field = jQuery("#%s");
-                        options = %s;
+                        options = $.extend({}, default_options, %s);
                         options.imageUploadErrorCallback = function(json){
                             alert(json.error);
                         };


### PR DESCRIPTION
One should define default_options variable in `jquery.redactor.init.js`.
This is useful in case of need to define custom `syncCallback` or `syncBeforeCallback`.