### PR TITLE
Fix jQuery initialization

### DIFF
--- a/redactor/static/redactor/jquery.redactor.init.js
+++ b/redactor/static/redactor/jquery.redactor.init.js
@@ -1,5 +1,5 @@
-if(typeof django !== "undefined") {
-    jQuery = django.jQuery.noConflict(true);
+if (typeof jQuery === 'undefined' && django && django.jQuery) {
+    jQuery = django.jQuery;
 }
 
 /**

--- a/redactor/static/redactor/jquery.redactor.init.js
+++ b/redactor/static/redactor/jquery.redactor.init.js
@@ -9,27 +9,28 @@ so it can be used as part of an inline formset.
 Credit to the approach taken in:
 https://github.com/yourlabs/django-autocomplete-light
 **/
-jQuery(document).ready(function() {
-    jQuery('textarea.redactor-box').on('initialize', function() {
-        redactor_options = jQuery(this).data('redactor-options');
-        redactor_options.imageUploadErrorCallback = function (json) {
-            // TODO: Needs better error messages
-            alert(json.error);
-        }
-        jQuery(this).redactor(redactor_options);
+(function($) {
+    $(document).ready(function() {
+        $('textarea.redactor-box').on('initialize', function() {
+            redactor_options = $(this).data('redactor-options');
+            redactor_options.imageUploadErrorCallback = function (json) {
+                // TODO: Needs better error messages
+                alert(json.error);
+            }
+            $(this).redactor(redactor_options);
+        });
+        $(document).trigger('redactorWidgetReady');
+
+        $('textarea.redactor-box:not([id*="__prefix__"])').each(function() {
+            $(this).trigger('initialize');
+        });
+
+        $(document).bind('DOMNodeInserted', function(e) {
+            var widget = $(e.target).find('.redactor-box');
+
+            if (!widget.length) return;
+
+            widget.trigger('initialize');
+        });
     });
-    jQuery(document).trigger('redactorWidgetReady');
-
-    jQuery('textarea.redactor-box:not([id*="__prefix__"])').each(function() {
-        jQuery(this).trigger('initialize');
-    });
-
-     jQuery(document).bind('DOMNodeInserted', function(e) {
-        var widget = jQuery(e.target).find('.redactor-box');
-
-        if (!widget.length) return;
-
-        widget.trigger('initialize');
-    });
-
-});
+})(jQuery);

--- a/redactor/static/redactor/jquery.redactor.init.js
+++ b/redactor/static/redactor/jquery.redactor.init.js
@@ -2,16 +2,9 @@ if (typeof jQuery === 'undefined' && django && django.jQuery) {
     jQuery = django.jQuery;
 }
 
-/**
-This makes sure that we initialise the redactor on the text area once its displayed
-so it can be used as part of an inline formset.
-
-Credit to the approach taken in:
-https://github.com/yourlabs/django-autocomplete-light
-**/
 (function($) {
     $(document).ready(function() {
-        $('textarea.redactor-box').on('initialize', function() {
+        $(document).on('redactor:init', 'textarea.redactor-box', function() {
             redactor_options = $(this).data('redactor-options');
             redactor_options.imageUploadErrorCallback = function (json) {
                 // TODO: Needs better error messages
@@ -22,15 +15,20 @@ https://github.com/yourlabs/django-autocomplete-light
         $(document).trigger('redactorWidgetReady');
 
         $('textarea.redactor-box:not([id*="__prefix__"])').each(function() {
-            $(this).trigger('initialize');
+            $(this).trigger('redactor:init');
         });
 
-        $(document).bind('DOMNodeInserted', function(e) {
-            var widget = $(e.target).find('.redactor-box');
-
-            if (!widget.length) return;
-
-            widget.trigger('initialize');
+        // Initialize Redactor on admin's dynamically-added inline
+        // formsets.
+        //
+        // Credit to the approach taken in django-selectable:
+        // https://github.com/mlavin/django-selectable
+        $(document).on('click', '.add-row', function () {
+            $(this)
+                .parents('.inline-related')
+                .find('.form-row:not(.empty-form)').last()
+                .find('textarea.redactor-box')
+                .trigger('redactor:init');
         });
     });
 })(jQuery);


### PR DESCRIPTION
Fix #80 by only setting `window.jQuery` if it doesn't exist, and also allow `window.jQuery` to be set to a new jQuery instance after Redactor loads. See commit messages for details!