### PR TITLE
Added nojs options to settings. Disables automatically including JS library files.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -187,22 +187,28 @@ Manual JS Loading
 
 Turns off automatically including redactor JS loading on page load.
 
-.. code-block::
+.. code-block:: python
     
     // Settings option
     REDACTOR_OPTIONS = {'nojs': True}
 
 The following JS files must be included in order to load the editor.
 
-.. code-block::
+.. code-block:: html
 
     <script type="text/javascript" src="{% static 'redactor/jquery.redactor.init.js' %}"></script>
     <script type="text/javascript" src="{% static 'redactor/redactor.js' %}"></script>
+    
+You must include all plugins and language files manually.
+    
+.. code-block:: html
+
     <script type="text/javascript" src="{% static 'redactor/langs/en.js' %}"></script>
+    <script type="text/javascript" src="{% static 'redactor/plugins/tables.js' %}"></script>
 
-Note when loading redactor through ajax you must call the following JS to initialize redactor.
+When loading forms through ajax you must call the following JS to initialize redactor editors.
 
-.. code-block::
+.. code-block:: javascript
 
     $('textarea.redactor-box:not([id*="__prefix__"])').each(function() {
         $(this).trigger('redactor:init');

--- a/README.rst
+++ b/README.rst
@@ -182,6 +182,34 @@ Other third-party libraries exist to provide storage backends for cloud object s
     AWS_SECRET_ACCESS_KEY = '...'
     AWS_STORAGE_BUCKET_NAME = '...'
 
+Manual JS Loading
+-----------------
+
+Turns off automatically including redactor JS loading on page load.
+
+.. code-block::
+    
+    // Settings option
+    REDACTOR_OPTIONS = {'nojs': True}
+
+The following JS files must be included in order to load the editor.
+
+.. code-block::
+
+    <script type="text/javascript" src="{% static 'redactor/jquery.redactor.init.js' %}"></script>
+    <script type="text/javascript" src="{% static 'redactor/redactor.js' %}"></script>
+    <script type="text/javascript" src="{% static 'redactor/langs/en.js' %}"></script>
+
+Note when loading redactor through ajax you must call the following JS to initialize redactor.
+
+.. code-block::
+
+    $('textarea.redactor-box:not([id*="__prefix__"])').each(function() {
+        $(this).trigger('redactor:init');
+    });
+
+
+
 
 NOTE: Soon we will have a better documentation.
 

--- a/redactor/widgets.py
+++ b/redactor/widgets.py
@@ -47,18 +47,20 @@ class RedactorEditor(widgets.Textarea):
         return mark_safe(html)
 
     def _media(self):
-        js = (
-            'redactor/jquery.redactor.init.js',
-            'redactor/redactor.js',
-            'redactor/langs/{0}.js'.format(GLOBAL_OPTIONS.get('lang', 'en')),
-        )
-
-        if 'plugins' in self.options:
-            plugins = self.options.get('plugins')
-            for plugin in plugins:
-                js = js + (
-                    'redactor/plugins/{0}.js'.format(plugin),
-                )
+        if GLOBAL_OPTIONS.get('nojs', False) == False:
+            js = (
+                'redactor/jquery.redactor.init.js',
+                'redactor/redactor.js',
+                'redactor/langs/{0}.js'.format(GLOBAL_OPTIONS.get('lang', 'en')),
+            )
+            if 'plugins' in self.options:
+                plugins = self.options.get('plugins')
+                for plugin in plugins:
+                    js = js + (
+                        'redactor/plugins/{0}.js'.format(plugin),
+                    )
+        else:
+            js = ()
 
         css = {
             'all': (


### PR DESCRIPTION
This adds the option for turning off automatic inclusion of the JS files on page load and forces them to be manually included.

I added this since I pull the editor through ajax and default method of having the JS load through the form media was not working.

This disables all JS inclusion and forces everything to be manually added ... 
