### PR TITLE
Make stacked inlines work

### DIFF
--- a/redactor/static/redactor/jquery.redactor.init.js
+++ b/redactor/static/redactor/jquery.redactor.init.js
@@ -30,10 +30,17 @@ if (typeof redactor_custom_options === 'undefined') {
         // Credit to the approach taken in django-selectable:
         // https://github.com/mlavin/django-selectable
         $(document).on('click', '.add-row', function () {
-            $(this).parents('.inline-related')
-                   .find('tr.form-row:not(.empty-form)').last()
-                   .find('textarea.redactor-box')
-                   .trigger('redactor:init');
+            var add_row = $(this);
+            var row =
+                add_row.parents('.inline-related')
+                       .find('tr.form-row:not(.empty-form)').last();
+            if (row.length === 0) {
+                row =
+                    add_row.parents('.inline-group')
+                           .find('.last-related:not(.empty-form)').last();
+            }
+            row.find('textarea.redactor-box')
+               .trigger('redactor:init');
         });
     });
 })(jQuery);


### PR DESCRIPTION
This PR initializes redactor editors in stacked inlines as well.

I had problems with Django 1.8 and django-wysiwyg-redactor 0.4.9, where initializing additional editors works only for tabular inlines.

The code could be more elegant, but I decided to go with the `.length === 0` check in order to keep the original logic intact and not to miss corner cases that have been addressed by the original version.