### PR TITLE
Update README to resolve Issue #104

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ or use custom parametrs:
 
     short_text = RedactorField(
         verbose_name=u'Text',
-        redactor_options={'lang': 'en', 'focus': 'true'},
+        redactor_options={'lang': 'en', 'focus': True},
         upload_to='tmp/',
         allow_file_upload=True,
         allow_image_upload=True


### PR DESCRIPTION
Boolean redactor_options need to be set using Python booleans rather than strings.

If set using strings, the settings don't work.