### PR TITLE
Widget render is removing all other calsses

### DIFF
--- a/redactor/widgets.py
+++ b/redactor/widgets.py
@@ -6,6 +6,7 @@ from django.conf import settings
 
 from redactor.utils import json_dumps
 
+import re
 
 GLOBAL_OPTIONS = getattr(settings, 'REDACTOR_OPTIONS', {})
 

--- a/redactor/widgets.py
+++ b/redactor/widgets.py
@@ -35,15 +35,13 @@ class RedactorEditor(widgets.Textarea):
         return options
 
     def render(self, name, value, attrs=None):
-        if 'class' not in attrs.keys():
-            attrs['class'] = ''
-
-        attrs['class'] += ' redactor-box'
-
         attrs['data-redactor-options'] = json_dumps(self.options)
 
         html = super(RedactorEditor, self).render(name, value, attrs)
 
+        eclass = re.search("class=\"([^\\\"]*)\"", html)
+        attrs['class'] = '%s %s' % (eclass.group(1), 'redactor-box')
+        html = super(RedactorEditor, self).render(name, value, attrs)
         return mark_safe(html)
 
     def _media(self):


### PR DESCRIPTION
I had a problem with redactor and modeltranslation-tabs and I found out that redactor widget render method is removing all the classes added by other apps. 
My solution doesn't seem a proper way to do this but since I'm not a pro python developer that's the only way I found for that. and it fixes my issue with the modeltrasnlation tabs.