### PR TITLE
Remove `django.conf.urls.patterns`

### DIFF
--- a/redactor/urls.py
+++ b/redactor/urls.py
@@ -1,15 +1,13 @@
 try:
-    from django.conf.urls import url, patterns
+    from django.conf.urls import url
 except ImportError:
     # for Django version less than 1.4
-    from django.conf.urls.defaults import url, patterns
+    from django.conf.urls.defaults import url
 
 from redactor.views import RedactorUploadView
 from redactor.forms import FileForm, ImageForm
 
-
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^upload/image/(?P<upload_to>.*)',
         RedactorUploadView.as_view(form_class=ImageForm),
         name='redactor_upload_image'),
@@ -17,4 +15,4 @@ urlpatterns = patterns(
     url(r'^upload/file/(?P<upload_to>.*)',
         RedactorUploadView.as_view(form_class=FileForm),
         name='redactor_upload_file'),
-)
+]


### PR DESCRIPTION
Since they already have been removed from the doc and will be removed in Django 2.0

This removes the Warning

```
site-packages/redactor/urls.py:19: RemovedInDjango110Warning: django.conf.urls.patterns()
is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of
django.conf.urls.url() instances instead.
  name='redactor_upload_file'),
```