### PR TITLE
change urls.py to django.conf.urls.url() instance

### DIFF
--- a/redactor/urls.py
+++ b/redactor/urls.py
@@ -8,8 +8,7 @@ from redactor.views import RedactorUploadView
 from redactor.forms import FileForm, ImageForm
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^upload/image/(?P<upload_to>.*)',
         RedactorUploadView.as_view(form_class=ImageForm),
         name='redactor_upload_image'),
@@ -17,4 +16,5 @@ urlpatterns = patterns(
     url(r'^upload/file/(?P<upload_to>.*)',
         RedactorUploadView.as_view(form_class=FileForm),
         name='redactor_upload_file'),
-)
+]
+


### PR DESCRIPTION
fixes RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead exception.