### PR TITLE
django.conf.urls.patterns()

### DIFF
--- a/redactor/urls.py
+++ b/redactor/urls.py
@@ -1,5 +1,5 @@
 try:
-    from django.conf.urls import url, patterns
+    from django.conf.urls import url
 except ImportError:
     # for Django version less than 1.4
     from django.conf.urls.defaults import url, patterns
@@ -8,8 +8,7 @@ from redactor.views import RedactorUploadView
 from redactor.forms import FileForm, ImageForm
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^upload/image/(?P<upload_to>.*)',
         RedactorUploadView.as_view(form_class=ImageForm),
         name='redactor_upload_image'),
@@ -17,4 +16,4 @@ urlpatterns = patterns(
     url(r'^upload/file/(?P<upload_to>.*)',
         RedactorUploadView.as_view(form_class=FileForm),
         name='redactor_upload_file'),
-)
+]


### PR DESCRIPTION
django.conf.urls.patterns() is deprecated and will be removed in Django 1.10.