### PR TITLE
Add possibility to use custom jquery version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -185,6 +185,13 @@ Other third-party libraries exist to provide storage backends for cloud object s
 
 NOTE: Soon we will have a better documentation.
 
+Use custom jQuery version
+---------------------
+
+.. code-block:: python
+
+    REDACTOR_OPTIONS = {'jquery': 'https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.js'}
+    
 Contributing
 ------------
 

--- a/README.rst
+++ b/README.rst
@@ -185,13 +185,13 @@ Other third-party libraries exist to provide storage backends for cloud object s
 
 NOTE: Soon we will have a better documentation.
 
-Use custom jQuery version
+Using custom jQuery version
 ---------------------
 
 .. code-block:: python
 
     REDACTOR_OPTIONS = {'jquery': 'https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.js'}
-    
+
 Contributing
 ------------
 

--- a/redactor/widgets.py
+++ b/redactor/widgets.py
@@ -47,18 +47,21 @@ class RedactorEditor(widgets.Textarea):
         return mark_safe(html)
 
     def _media(self):
-        js = (
+        js = []
+
+        if self.options.get('jquery'):
+            js.append(self.options.get('jquery'))
+
+        js.extend([
             'redactor/jquery.redactor.init.js',
             'redactor/redactor{0}.js'.format('' if settings.DEBUG else '.min'),
             'redactor/langs/{0}.js'.format(GLOBAL_OPTIONS.get('lang', 'en')),
-        )
+        ])
 
         if 'plugins' in self.options:
             plugins = self.options.get('plugins')
             for plugin in plugins:
-                js = js + (
-                    'redactor/plugins/{0}.js'.format(plugin),
-                )
+                js.append('redactor/plugins/{0}.js'.format(plugin))
 
         css = {
             'all': (


### PR DESCRIPTION
Hi @douglasmiranda,

Thank you for your open source contribution. I've faced situation that I had legacy django version supplied with old jquery. So I thought it would be convenient that I can set jquery version over settings.py.

This PR adds possibility of that, you can set it just to add ```jquery``` key to ```REDACTOR_OPTIONS``` dictionary: 

```python
REDACTOR_OPTIONS = {'lang': 'en', 'jquery': 'https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.js'}
```