### PR TITLE
removed django.conf.urls.patterns

### DIFF
--- a/redactor/urls.py
+++ b/redactor/urls.py
@@ -1,15 +1,11 @@
-try:
-    from django.conf.urls import url, patterns
-except ImportError:
-    # for Django version less than 1.4
-    from django.conf.urls.defaults import url, patterns
+
+from django.conf.urls import url
 
 from redactor.views import RedactorUploadView
 from redactor.forms import FileForm, ImageForm
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^upload/image/(?P<upload_to>.*)',
         RedactorUploadView.as_view(form_class=ImageForm),
         name='redactor_upload_image'),
@@ -17,4 +13,4 @@ urlpatterns = patterns(
     url(r'^upload/file/(?P<upload_to>.*)',
         RedactorUploadView.as_view(form_class=FileForm),
         name='redactor_upload_file'),
-)
+]


### PR DESCRIPTION
Hi.
I have removed obsolete django.conf.urls.patterns due to it has already been removed in the upcoming Django 1.10 release.