### PR TITLE
stop editing global config

### DIFF
--- a/redactor/widgets.py
+++ b/redactor/widgets.py
@@ -10,7 +10,7 @@ from redactor.utils import json_dumps
 class RedactorEditor(widgets.Textarea):
     def __init__(self, *args, **kwargs):
         upload_to = kwargs.pop('upload_to', '')
-        self.options = getattr(settings, 'REDACTOR_OPTIONS', {})
+        self.options = dict(getattr(settings, 'REDACTOR_OPTIONS', {}))
         self.options.update(kwargs.pop('redactor_options', {}))
 
         if kwargs.pop('allow_file_upload', True):


### PR DESCRIPTION
The code is referencing the global configuration and modifying it directly instead of making a local copy and updating it.

I noticed that when I had two different forms with different settings, they both used the exact same settings because one was overwriting the other.